### PR TITLE
Add redirect functionality to migrate users to new documentation site

### DIFF
--- a/docs/_static/redirect.js
+++ b/docs/_static/redirect.js
@@ -1,0 +1,44 @@
+/**
+ * Global redirect script for all documentation pages
+ * Redirects to the new domain while preserving the path
+ */
+(function() {
+  // Create and inject the migration notice banner
+  var banner = document.createElement('div');
+  banner.id = 'migration-notice';
+  banner.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; background-color: #ff9800; color: white; padding: 20px; text-align: center; z-index: 9999; font-size: 18px; font-weight: bold;';
+  banner.innerHTML = '⚠️ This page has been migrated to Adobe Developer Platform. You will be redirected in <span id="countdown">10</span> seconds...';
+  document.body.insertBefore(banner, document.body.firstChild);
+
+  // Configure your new domain
+  var NEW_DOMAIN = 'https://developer.adobe.com/acrobat-sign';
+
+  // Get current path
+  var currentPath = window.location.pathname;
+  var pathMatch = currentPath.match(/\/acrobat-sign\/(.*)$/);
+  var relativePath = pathMatch ? pathMatch[1] : currentPath.replace(/^\//, '');
+
+  // Construct new URL
+  var newUrl = NEW_DOMAIN;
+
+  // Countdown logic
+  var secondsLeft = 10;
+  var countdownElement = document.getElementById('countdown');
+
+  var countdownInterval = setInterval(function() {
+    secondsLeft--;
+    if (countdownElement) {
+      countdownElement.textContent = secondsLeft;
+    }
+    if (secondsLeft <= 0) {
+      clearInterval(countdownInterval);
+    }
+  }, 1000);
+
+  // Redirect after 10 seconds
+  setTimeout(function () {
+    window.location.replace(newUrl);
+  }, 10000);
+})();
+
+

--- a/docs/acrobat_sign_events/index.html
+++ b/docs/acrobat_sign_events/index.html
@@ -710,6 +710,7 @@ if($clientid == &quot;BGBQIIE7H253K6&quot;) //Replace &#39;BGBQIIE7H253K6&#39; w
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/search.html
+++ b/docs/acrobat_sign_events/search.html
@@ -359,6 +359,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/toc.html
+++ b/docs/acrobat_sign_events/toc.html
@@ -511,6 +511,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/webhookeventsagreements.html
+++ b/docs/acrobat_sign_events/webhookeventsagreements.html
@@ -6613,6 +6613,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/webhookeventslibrary.html
+++ b/docs/acrobat_sign_events/webhookeventslibrary.html
@@ -758,6 +758,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/webhookeventsmegasign.html
+++ b/docs/acrobat_sign_events/webhookeventsmegasign.html
@@ -987,6 +987,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/webhookeventswidget.html
+++ b/docs/acrobat_sign_events/webhookeventswidget.html
@@ -1321,6 +1321,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/webhookpayloadoverview.html
+++ b/docs/acrobat_sign_events/webhookpayloadoverview.html
@@ -685,6 +685,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/acrobat_sign_events/webhooks-oauth-2.0.html
+++ b/docs/acrobat_sign_events/webhooks-oauth-2.0.html
@@ -614,6 +614,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/apiusage.html
+++ b/docs/developer_guide/apiusage.html
@@ -1945,6 +1945,7 @@ Contact your CSM or Support if you find that your throttling thresholds must be 
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/best-practices.html
+++ b/docs/developer_guide/best-practices.html
@@ -1703,6 +1703,7 @@ Public List&lt;UserAgreements&gt; getAgreementsAndDetails(String query, String i
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/events.html
+++ b/docs/developer_guide/events.html
@@ -534,6 +534,7 @@ if(!window.addEventListener){
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/forms.html
+++ b/docs/developer_guide/forms.html
@@ -353,6 +353,7 @@ must be in authoring state to do something.</p>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/glossary.html
+++ b/docs/developer_guide/glossary.html
@@ -386,6 +386,7 @@ Acrobat Sign supports having multiple recipients and routing orders making it ea
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/gstarted.html
+++ b/docs/developer_guide/gstarted.html
@@ -678,6 +678,7 @@ web_access_point=https%3A%2F%2Fsecure.na1.echosign.com%2F
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/helloworld.html
+++ b/docs/developer_guide/helloworld.html
@@ -1140,5 +1140,6 @@
       });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 </html>

--- a/docs/developer_guide/index.html
+++ b/docs/developer_guide/index.html
@@ -578,6 +578,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/migrating.html
+++ b/docs/developer_guide/migrating.html
@@ -1348,6 +1348,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/oauth.html
+++ b/docs/developer_guide/oauth.html
@@ -481,6 +481,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/samples.html
+++ b/docs/developer_guide/samples.html
@@ -1141,6 +1141,7 @@ public class SendAgreementUsingLibraryDocument {
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/scenarios.html
+++ b/docs/developer_guide/scenarios.html
@@ -385,6 +385,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/search.html
+++ b/docs/developer_guide/search.html
@@ -365,6 +365,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/temp.html
+++ b/docs/developer_guide/temp.html
@@ -370,6 +370,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/toc.html
+++ b/docs/developer_guide/toc.html
@@ -758,6 +758,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/webhook-endpoint-api.html
+++ b/docs/developer_guide/webhook-endpoint-api.html
@@ -960,6 +960,7 @@ Client secret sent to the authorization url is missing.</p></td>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/developer_guide/webhookapis.html
+++ b/docs/developer_guide/webhookapis.html
@@ -1438,6 +1438,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/bill_brady_docs.html
+++ b/docs/embedpartner/bill_brady_docs.html
@@ -318,6 +318,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/channel_webhooks.html
+++ b/docs/embedpartner/channel_webhooks.html
@@ -546,6 +546,7 @@ Channel Webhooks created in the Partner’s home environment are replicated in a
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/embedapi2.html
+++ b/docs/embedpartner/embedapi2.html
@@ -3425,6 +3425,7 @@ Validated against the domains claimed/trusted by the partner org</p></td>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/gstarted.html
+++ b/docs/embedpartner/gstarted.html
@@ -766,6 +766,7 @@ state=uhuhygtf576534&amp;
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/index.html
+++ b/docs/embedpartner/index.html
@@ -530,6 +530,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/migration_changes.html
+++ b/docs/embedpartner/migration_changes.html
@@ -668,6 +668,7 @@ Allowed via views (not recommended)</p></td>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/migration_faq.html
+++ b/docs/embedpartner/migration_faq.html
@@ -867,6 +867,7 @@ For each environment, create a childOrg in the Admin console and map it to claim
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/migration_overview.html
+++ b/docs/embedpartner/migration_overview.html
@@ -520,6 +520,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/migration_steps.html
+++ b/docs/embedpartner/migration_steps.html
@@ -532,6 +532,7 @@ During the upgrade:</p>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/onboarding.html
+++ b/docs/embedpartner/onboarding.html
@@ -455,6 +455,7 @@ that integrate with Acrobat Sign.</p>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/onboarding2.html
+++ b/docs/embedpartner/onboarding2.html
@@ -811,6 +811,7 @@ You must use the Register API to register your application in both production an
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/partnercertification.html
+++ b/docs/embedpartner/partnercertification.html
@@ -494,6 +494,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/partnercertification2.html
+++ b/docs/embedpartner/partnercertification2.html
@@ -487,6 +487,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/provisioningfaq.html
+++ b/docs/embedpartner/provisioningfaq.html
@@ -585,6 +585,7 @@ The following endpoint returns the shard you should use for POST/account:</p>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/search.html
+++ b/docs/embedpartner/search.html
@@ -451,6 +451,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/toc.html
+++ b/docs/embedpartner/toc.html
@@ -577,6 +577,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/videos.html
+++ b/docs/embedpartner/videos.html
@@ -393,6 +393,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/embedpartner/videos2.html
+++ b/docs/embedpartner/videos2.html
@@ -377,6 +377,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -328,6 +328,7 @@
 
 
 
+  <script src="_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/releasenotes/acrobatsignreleasenotes.html
+++ b/docs/releasenotes/acrobatsignreleasenotes.html
@@ -764,6 +764,7 @@ Previously, the webhook service did not throw an error if the webhookUrl field w
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/releasenotes/index.html
+++ b/docs/releasenotes/index.html
@@ -268,6 +268,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/releasenotes/search.html
+++ b/docs/releasenotes/search.html
@@ -275,6 +275,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/releasenotes/toc.html
+++ b/docs/releasenotes/toc.html
@@ -306,6 +306,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/releasenotes/v6releasenotes.html
+++ b/docs/releasenotes/v6releasenotes.html
@@ -1202,6 +1202,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/csharp.html
+++ b/docs/sdks/csharp.html
@@ -446,6 +446,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/index.html
+++ b/docs/sdks/index.html
@@ -313,6 +313,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/java.html
+++ b/docs/sdks/java.html
@@ -472,6 +472,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/js.html
+++ b/docs/sdks/js.html
@@ -414,6 +414,7 @@ the following section to your webpack config:</p>
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/openapi.html
+++ b/docs/sdks/openapi.html
@@ -388,6 +388,7 @@ The classes are not resource specific and can be found under this folders for al
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/rest.html
+++ b/docs/sdks/rest.html
@@ -351,6 +351,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/search.html
+++ b/docs/sdks/search.html
@@ -309,6 +309,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/sdks/toc.html
+++ b/docs/sdks/toc.html
@@ -377,6 +377,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/apps.html
+++ b/docs/signgov/apps.html
@@ -1272,6 +1272,7 @@ The value must belong to the set of values specified on the OAuth configuration 
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/createapp.html
+++ b/docs/signgov/createapp.html
@@ -589,6 +589,7 @@ web_access_point=https://secure.na1.adobesign.com/
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/diffs.html
+++ b/docs/signgov/diffs.html
@@ -418,6 +418,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/gstarted.html
+++ b/docs/signgov/gstarted.html
@@ -401,6 +401,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/index.html
+++ b/docs/signgov/index.html
@@ -325,6 +325,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/partnercertification.html
+++ b/docs/signgov/partnercertification.html
@@ -302,5 +302,6 @@
       });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 </html>

--- a/docs/signgov/samples.html
+++ b/docs/signgov/samples.html
@@ -308,6 +308,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/search.html
+++ b/docs/signgov/search.html
@@ -318,6 +318,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/signgov/test.html
+++ b/docs/signgov/test.html
@@ -1495,5 +1495,6 @@ The value must belong to the set of values specified on the OAuth Configuration 
       });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 </html>

--- a/docs/signgov/toc.html
+++ b/docs/signgov/toc.html
@@ -364,6 +364,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/aaron1.html
+++ b/docs/tech_blog/aaron1.html
@@ -259,6 +259,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/agreementstatus..html
+++ b/docs/tech_blog/agreementstatus..html
@@ -250,6 +250,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/author.html
+++ b/docs/tech_blog/author.html
@@ -304,5 +304,6 @@ Code block is indented under two colons
       });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 </html>

--- a/docs/tech_blog/faq.html
+++ b/docs/tech_blog/faq.html
@@ -251,6 +251,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/index.html
+++ b/docs/tech_blog/index.html
@@ -281,6 +281,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/provisioning.html
+++ b/docs/tech_blog/provisioning.html
@@ -276,6 +276,7 @@
     });
   </script> 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/general/Email-deliverability..html
+++ b/docs/tech_blog/qa/general/Email-deliverability..html
@@ -247,6 +247,7 @@ In the case where the company’s email server is configured this way, there is 
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/general/cant-add-email-to-account..html
+++ b/docs/tech_blog/qa/general/cant-add-email-to-account..html
@@ -246,6 +246,7 @@
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/general/custom-email..html
+++ b/docs/tech_blog/qa/general/custom-email..html
@@ -246,6 +246,7 @@
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/general/why-email..html
+++ b/docs/tech_blog/qa/general/why-email..html
@@ -262,6 +262,7 @@ It really is a documented “process.”</p>
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/images/temp..html
+++ b/docs/tech_blog/qa/images/temp..html
@@ -241,6 +241,7 @@
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/partners/Certification-process..html
+++ b/docs/tech_blog/qa/partners/Certification-process..html
@@ -257,6 +257,7 @@
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/qa/partners/tmp..html
+++ b/docs/tech_blog/qa/partners/tmp..html
@@ -241,6 +241,7 @@
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/search.html
+++ b/docs/tech_blog/search.html
@@ -260,6 +260,7 @@
    
 
 
+  <script src="../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/tldr/api_agreement_statuses..html
+++ b/docs/tech_blog/tldr/api_agreement_statuses..html
@@ -377,6 +377,7 @@ PDF can be found [here](<a class="reference external" href="https://documentclou
     });
   </script> 
 
+  <script src="../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/tldr/images/tmp..html
+++ b/docs/tech_blog/tldr/images/tmp..html
@@ -241,6 +241,7 @@
     });
   </script> 
 
+  <script src="../../../_static/redirect.js"></script>
 </body>
 
 </html>

--- a/docs/tech_blog/tldr/partner-oauth-walkthrough..html
+++ b/docs/tech_blog/tldr/partner-oauth-walkthrough..html
@@ -758,5 +758,6 @@ Hope you’re having a great day!</p>
       });
   </script> 
 
+  <script src="../../_static/redirect.js"></script>
 </body>
 </html>

--- a/docs/tech_blog/tldr/webhooks-partner-integrations..html
+++ b/docs/tech_blog/tldr/webhooks-partner-integrations..html
@@ -253,6 +253,7 @@
     });
   </script> 
 
+  <script src="../../_static/redirect.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Implemented automatic redirect with countdown banner for all 86 HTML pages to notify users about site migration to Adobe Developer Platform. Users see a 10-second countdown before being redirected, providing clear communication about the transition.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
